### PR TITLE
Handle invalid auth cookie input gracefully

### DIFF
--- a/application/helpers/general_helper.php
+++ b/application/helpers/general_helper.php
@@ -328,8 +328,18 @@ function cookie_delete()
 function verify_cookie()
 {
 
+    if (!isset($_COOKIE['auth_cookie']) || !strlen($_COOKIE['auth_cookie'])) {
+        return false;
+    }
+
     //Authenticate Cookie:
     $cookie_parts = explode('ABCEFG', $_COOKIE['auth_cookie']);
+
+    if (count($cookie_parts) < 3 || !strlen($cookie_parts[0]) || !strlen($cookie_parts[1])) {
+        cookie_delete();
+        return false;
+    }
+
     $CI =& get_instance();
 
     $es = $CI->Users->read(array(
@@ -342,13 +352,11 @@ function verify_cookie()
         $CI->Users->activate($es[0], false, true);
         return $es[0];
 
-    } else {
-
-        //Cookie was invalid
-        cookie_delete();
-        return false;
-
     }
+
+    //Cookie was invalid
+    cookie_delete();
+    return false;
 
 }
 


### PR DESCRIPTION
## Summary
- prevent verify_cookie from running when no auth cookie is set
- validate the cookie structure before attempting to read session data
- clear malformed cookies to avoid undefined index notices

## Testing
- php -l application/helpers/general_helper.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fea6d358c8333a9c53d02c942cc99)