### PR TITLE
Fix chain updates to use formatted post index value

### DIFF
--- a/application/models/Posts.php
+++ b/application/models/Posts.php
@@ -261,7 +261,7 @@ class Posts extends CIdea_cache
                     $this->Chains->update($chain_i['chainid'], array(
                         'chainpostinput' => $postid,
                         'chainusercreator' => $chainusercreator,
-                        'chainvalue' => '#' . (isset($update_columns['posthashtag']) ? $update_columns['posthashtag'] : $post_current['posthashtag']) . "\n" . $post_index['postmessageraw'],
+                        'chainvalue' => '#' . (isset($update_columns['posthashtag']) ? $update_columns['posthashtag'] : $post_current['posthashtag']) . "\n" . $post_index['chainvalue'],
                     ));
                 }
             }


### PR DESCRIPTION
## Summary
- ensure Posts::update stores the formatted post index content in chainvalue when updating a post

## Testing
- php -l application/models/Posts.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910d4392cc08333acc086318f8db81b)